### PR TITLE
Fix compilation on Red Hat derived distros

### DIFF
--- a/dmabuf.h
+++ b/dmabuf.h
@@ -17,7 +17,10 @@
 #include <linux/dma-map-ops.h>
 #endif
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0) // `vm_flags_set`
+// `vm_flags_set`
+// These functions were added in kernel v6.3, but Red Hat backported to their v5.14 kernels used in the 9.6 distro releases.
+// Hence the check on the Red Hat version if it is Red Hat.
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0) && (!defined RHEL_RELEASE_CODE || (RHEL_RELEASE_CODE < RHEL_RELEASE_VERSION(9, 6)))
 static inline
 void vm_flags_set(struct vm_area_struct* vma, vm_flags_t flags) {
     vma->vm_flags |= flags;


### PR DESCRIPTION
On Rocky Linux 9.6 I get errors like:
```
In file included from /home/mu3e/online/online-git/common/kerneldriver/mudaq.c:8:
/home/mu3e/online/online-git/common/kerneldriver/dmabuf/dmabuf.h:26:6: error: redefinition of ‘vm_flags_set’
```


`vm_flags_set` and `vm_flags_clear` were introduced in official kernel v6.3, which the current code checks for. Red Hat 9.6 derived distros, in my case Rocky, have these defined even though they use kernel v5.14. So Red Hat must have back ported them. This change skips the local implementation if the system is Red Hat derived and the Red Hat version is 9.6 or higher.

Tested with `#undef RHEL_RELEASE_CODE` and `#define RHEL_RELEASE_CODE <different values>` before the code in question. I have not tested on a system other than Rocky.