### PR TITLE
Fix issues on non-RedHat systems caused by the previous RedHat fix

### DIFF
--- a/dmabuf.h
+++ b/dmabuf.h
@@ -20,7 +20,16 @@
 // `vm_flags_set`
 // These functions were added in kernel v6.3, but Red Hat backported to their v5.14 kernels used in the 9.6 distro releases.
 // Hence the check on the Red Hat version if it is Red Hat.
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0) && (!defined RHEL_RELEASE_CODE || (RHEL_RELEASE_CODE < RHEL_RELEASE_VERSION(9, 6)))
+#ifdef RHEL_RELEASE_CODE
+#   if RHEL_RELEASE_CODE < RHEL_RELEASE_VERSION(9, 6)
+#       define REQUIRE_VM_FLAGS_POLYFILL
+#   endif
+#else
+#   if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
+#       define REQUIRE_VM_FLAGS_POLYFILL
+#   endif
+#endif
+#ifdef REQUIRE_VM_FLAGS_POLYFILL
 static inline
 void vm_flags_set(struct vm_area_struct* vma, vm_flags_t flags) {
     vma->vm_flags |= flags;


### PR DESCRIPTION
I'm not sure if this is compiler dependent or if it was just a poor fix, but some (all?) non RedHat systems complain about the use of `RHEL_RELEASE_VERSION`. The previous `!defined RHEL_RELEASE_CODE` should naively short circuit the check but it doesn't.

So this now explicitly checks if the system is RedHat before using `RHEL_RELEASE_VERSION`. I couldn't find a cleaner way of doing it, and I don't think a "one liner" is possible.